### PR TITLE
refactor: Migrate deployment to ECR pipeline

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,8 +4,39 @@ on:
   push:
     branches: ["develop"]
 
+env:
+  AWS_REGION: us-east-1
+  ECR_REGISTRY: 084375578827.dkr.ecr.us-east-1.amazonaws.com
+
 jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push backend
+        run: |
+          docker build -f Dockerfile.backend -t ${{ env.ECR_REGISTRY }}/day-one-dev/backend:latest .
+          docker push ${{ env.ECR_REGISTRY }}/day-one-dev/backend:latest
+
+      - name: Build and push frontend
+        run: |
+          docker build -f Dockerfile.frontend -t ${{ env.ECR_REGISTRY }}/day-one-dev/frontend:latest .
+          docker push ${{ env.ECR_REGISTRY }}/day-one-dev/frontend:latest
+
   deploy:
+    needs: build-and-push
     runs-on: ubuntu-latest
     steps:
       - name: Deploy via SSH
@@ -18,7 +49,7 @@ jobs:
             set -e
             APP_DIR="${{ secrets.EC2_APP_DIR }}"
 
-            # First time: init repo (.env 등 기존 파일 보존)
+            # First time: init repo
             if [ ! -d "$APP_DIR/.git" ]; then
               mkdir -p "$APP_DIR"
               cd "$APP_DIR"
@@ -32,11 +63,15 @@ jobs:
             git fetch origin develop
             git reset --hard origin/develop
 
-            # Build and deploy with Docker Compose
-            docker compose down
-            docker compose up --build -d
+            # Login to ECR
+            aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 084375578827.dkr.ecr.us-east-1.amazonaws.com
 
-            # Wait and verify
+            # Pull and deploy
+            ECR_REGISTRY=084375578827.dkr.ecr.us-east-1.amazonaws.com
+            docker compose pull backend frontend
+            docker compose up -d
+
+            # Verify
             sleep 10
             docker compose ps
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,7 @@ services:
       retries: 5
 
   backend:
-    build:
-      context: .
-      dockerfile: Dockerfile.backend
+    image: ${ECR_REGISTRY}/day-one-dev/backend:latest
     environment:
       - DB_HOST=mysql
       - AWS_REGION=${AWS_REGION:-us-east-1}
@@ -32,9 +30,7 @@ services:
       - "8000:8000"
 
   frontend:
-    build:
-      context: .
-      dockerfile: Dockerfile.frontend
+    image: ${ECR_REGISTRY}/day-one-dev/frontend:latest
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## 📌 Summary
Migrate deployment from local Docker build on EC2 to GitHub Actions CI/CD with ECR.

---

## 🔗 Related Issue
Closes #6

---

## 🛠 Changes
- `docker-compose.yml`: Local build replaced with ECR image pull
- `deploy-dev.yml`: Added build-and-push job (GitHub Actions → ECR), deploy job pulls from ECR

---

## 🧪 How to Test
1. Merge to develop branch
2. Check GitHub Actions workflow runs successfully
3. SSH into EC2 and verify containers are running with `docker compose ps`

---

## ⚠️ Breaking Changes
- [x] Breaking changes included (explain below)
- EC2 requires IAM Role with ECR read access (handled in Day_One_Cloud)
- `ECR_REGISTRY` env var must be set on EC2
- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` secrets must be added to repo

---

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added/updated
- [x] No console errors
- [ ] Documentation updated
- [ ] CI passes