### PR TITLE
Block malicious path scanning in Nginx

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -23,6 +23,22 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Block sensitive paths
+    location ~ /\.git {
+        deny all;
+        return 404;
+    }
+
+    location ~ /\.env {
+        deny all;
+        return 404;
+    }
+
+    location /geoserver {
+        deny all;
+        return 404;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## 📌 Summary
Block sensitive path scanning (`.git/config`, `.env`, `/geoserver`) in Nginx that was returning 200 instead of 404.

---

## 🔗 Related Issue
Closes #26

---

## 🛠 Changes
- Add `location ~ /\.git` block → deny all, return 404
- Add `location ~ /\.env` block → deny all, return 404
- Add `location /geoserver` block → deny all, return 404
- All rules placed before SPA catch-all `try_files`

---

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added/updated
- [x] No console errors
- [ ] Documentation updated
- [ ] CI passes