### PR TITLE
[INFRA] Extend Prometheus histogram buckets for Gemini AI latency

### DIFF
--- a/firstbutton/src/backend/demo/codes/routers/schedule.py
+++ b/firstbutton/src/backend/demo/codes/routers/schedule.py
@@ -17,7 +17,8 @@ from startButton import integrated_file_reader, parse_response_to_events, google
 STEP_DURATION = Histogram(
     'upload_step_duration_seconds',
     'Duration of each upload pipeline step',
-    ['step']
+    ['step'],
+    buckets=[0.1, 0.5, 1, 2.5, 5, 10, 15, 30, 45, 60, 90, 120]
 )
 UPLOAD_FILE_SIZE = Histogram(
     'upload_file_size_bytes',


### PR DESCRIPTION
## 📌 Summary
Extend Prometheus Histogram bucket range for `upload_step_duration_seconds` to accurately capture Gemini AI latency (30-60s) in Grafana dashboards.

---

## 🔗 Related Issue
Closes #33

---

## 🛠 Changes
- Add custom histogram buckets `[0.1, 0.5, 1, 2.5, 5, 10, 15, 30, 45, 60, 90, 120]` to `STEP_DURATION` in `schedule.py`
- Default buckets capped at ~10s, causing 30-60s Gemini latency to display as ~7-10s in Grafana

---

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added/updated
- [x] No console errors
- [ ] Documentation updated
- [ ] CI passes