### PR TITLE
[INFRA] Add finer histogram buckets for 3-5s latency range

### DIFF
--- a/firstbutton/src/backend/demo/codes/routers/schedule.py
+++ b/firstbutton/src/backend/demo/codes/routers/schedule.py
@@ -18,7 +18,7 @@ STEP_DURATION = Histogram(
     'upload_step_duration_seconds',
     'Duration of each upload pipeline step',
     ['step'],
-    buckets=[0.1, 0.5, 1, 2.5, 5, 10, 15, 30, 45, 60, 90, 120]
+    buckets=[0.1, 0.5, 1, 2, 3, 4, 5, 7.5, 10, 15, 30, 45, 60, 90, 120]
 )
 UPLOAD_FILE_SIZE = Histogram(
     'upload_file_size_bytes',


### PR DESCRIPTION
## 📌 Summary
Add intermediate histogram buckets (2, 3, 4, 7.5s) to `STEP_DURATION` for more accurate Grafana graphs in the common Gemini AI response time range (3-5s).

---

## 🔗 Related Issue
#33

---

## 🛠 Changes
- Updated histogram buckets from `[0.1, 0.5, 1, 2.5, 5, 10, 15, 30, 45, 60, 90, 120]` to `[0.1, 0.5, 1, 2, 3, 4, 5, 7.5, 10, 15, 30, 45, 60, 90, 120]`
- Fixes flat-line graphs caused by too-wide bucket gaps in the 2.5-5s range

---

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added/updated
- [x] No console errors
- [ ] Documentation updated
- [ ] CI passes