### PR TITLE
feat: separate /metrics into dedicated thread (port 9091)

### DIFF
--- a/firstbutton/src/backend/demo/codes/main.py
+++ b/firstbutton/src/backend/demo/codes/main.py
@@ -1,11 +1,13 @@
 import config  # Secrets Manager 로드 (다른 모듈보다 먼저 import)
 import os
+import threading
 from fastapi import FastAPI, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from routers import schedule, auth
 from prometheus_fastapi_instrumentator import Instrumentator
+from prometheus_client import start_http_server
 
 app = FastAPI(title="첫단추 API")
 
@@ -15,7 +17,11 @@ UPLOAD_BUCKETS = (0.1, 0.5, 1, 2.5, 5, 7.5, 10, 15, 20, 30, 45, 60, 90, 120)
 Instrumentator().instrument(
     app,
     latency_lowr_buckets=UPLOAD_BUCKETS,
-).expose(app)
+)
+
+# /metrics를 별도 스레드(포트 9091)에서 서빙
+# 메인 앱이 부하로 바빠도 Prometheus 스크래핑이 즉시 응답
+threading.Thread(target=start_http_server, args=(9091,), daemon=True).start()
 
 async def read_index():
     """메인 인덱스 페이지 반환"""


### PR DESCRIPTION
## 📌 Summary
Moves Prometheus `/metrics` endpoint from main FastAPI process to a dedicated daemon thread on port 9091. Prevents scraping timeout during k6 load tests when Gemini API calls block the main uvicorn worker.

---

## 🔗 Related Issue
Closes #37

---

## 🛠 Changes
- `main.py`: Remove `.expose(app)`, add `start_http_server(9091)` on daemon thread
- `prometheus.yml` (Day_One_Cloud): Update scrape target `backend:8000` → `backend:9091`, restore interval/timeout to `5s`

---

## ✅ Checklist
- [ ] Code compiles
- [ ] Tests added/updated
- [ ] No console errors
- [ ] Documentation updated
- [ ] CI passes